### PR TITLE
add getUnitData() to tts models

### DIFF
--- a/lua_modules/MatchedPlay.lua
+++ b/lua_modules/MatchedPlay.lua
@@ -798,6 +798,9 @@ function recursivelyCleanElement(element)
 end
 
 
+function getUnitData() -- allow external TTS mods to access yellowscribe information
+    return unitData
+end
 
 
 


### PR DESCRIPTION
## Addition of getUnitData method to the lua script attached to each TTS model
The aim of this is to allow read access of Yellowscribe unit data from other TTS objects. In particular, this feature is requested to allow for external "No Prisoners" and "Bring It Down" secondary wound total trackers to be created.

