### PR TITLE
[rosterizer] discover sub-units recursively

### DIFF
--- a/bin/rosterizerParser.js
+++ b/bin/rosterizerParser.js
@@ -26,11 +26,7 @@ function extractRegistryJSON(rawData) {
 function parseRegistry(json) {
     let roster = new Model.Roster();
 
-    for (let asset of json.assets.included) {
-        if (asset.lineage.includes("Unit")) {
-            roster.addUnit(parseUnit(asset));
-        }
-    }
+    discoverUnits(json);
 
     for (let error of json.errors) {
         let errorText = error.message;
@@ -41,6 +37,15 @@ function parseRegistry(json) {
     }
 
     return roster;
+}
+
+function discoverUnits(asset) {
+    for (let subAsset of asset.assets.included) {
+        if (subAsset.lineage.includes("Unit")) {
+            roster.addUnit(parseUnit(subAsset));
+        }
+        discoverUnits(subAsset);
+    }
 }
 
 function parseModel(modelAsset, unit) {


### PR DESCRIPTION
Rosterizer will be supporting attaching leaders to bodyguard units. I'm not sure how that would want to be done in YS (and I've seen concerns that it would be suboptimal to even try) so my preliminary solution is to recursively dig through the units to see if they contain any sub-units, and simply add those to the processing queue.