### PR TITLE
Weapon labeling: [rosterizer] safer fallback

### DIFF
--- a/bin/rosterizerParser.js
+++ b/bin/rosterizerParser.js
@@ -131,12 +131,12 @@ function parseAndAddWeapon(weaponAsset, model, unit, namePrefix = null) {
         for (let subAsset of weaponAsset.assets.traits) {
             // The name of a profile should be prefixed with the name of the weapon.
             if (subAsset.classIdentity == "Weapon") {
-                let weaponName = weaponAsset.aspects.Label;
+                let weaponName = weaponAsset.aspects?.Label || weaponAsset.designation;
                 parseAndAddWeapon(subAsset, model, unit, weaponName);
             }
         }
     } else {
-        let name = weaponAsset.aspects.Label;
+        let name = weaponAsset.aspects?.Label || weaponAsset.designation;
         if (namePrefix != null) {
             name = namePrefix + " - " + name;
         }


### PR DESCRIPTION
Use safe property access to get the label, and fall back to designation if label isn't present.