### PR TITLE
Unbreak datacard close button when leader deleted

### DIFF
--- a/lua_modules/MatchedPlay.lua
+++ b/lua_modules/MatchedPlay.lua
@@ -486,6 +486,7 @@ end
 
 function updateEventHandlers(guid)
     self.UI.setAttribute("dataCardCloseButton", "onClick", guid.."/hideCard(dataCard)")
+    Global.UI.setAttribute("dataCardCloseButton", "onClick", guid.."/hideCard(dataCard)")
     self.UI.setValue("highlightButtonsContainer", interpolate(uiTemplates.buttons, { guid=guid, width=(unitData.uiWidth/10)-4 }))
 end
 


### PR DESCRIPTION
Deleting a leader from a unit causes subsequent datacards for that unit to not be able to close.
This line allows that because the self ui is copied to global, so we have to change it in both places.

In theory this should also work for the color buttons, which are also broken, but doing it for the colors resulta in doubling the qty of colored buttons instead of overwriting.