### PR TITLE
[rosterizer] units can be traits; check there also

### DIFF
--- a/bin/rosterizerParser.js
+++ b/bin/rosterizerParser.js
@@ -40,12 +40,14 @@ function parseRegistry(json) {
 }
 
 function discoverUnits(roster, asset) {
-    for (let subAsset of asset.assets.included) {
-        if (subAsset.lineage.includes("Unit")) {
-            roster.addUnit(parseUnit(subAsset, roster));
+    ['traits', 'included'].forEach(division => {
+        for (let subAsset of asset.assets[division]) {
+            if (subAsset.lineage.includes("Unit")) {
+                roster.addUnit(parseUnit(subAsset, roster));
+            }
+            discoverUnits(roster, subAsset);
         }
-        discoverUnits(roster, subAsset);
-    }
+    });
 }
 
 function parseModel(modelAsset, unit) {


### PR DESCRIPTION
Previously, ys only checked the roster/asset's included assets for units, but it should check traits as well, since units can be added to traits via rules and stats.