### PR TITLE
Introduced profileID to model table

### DIFF
--- a/tts-mod/src/Yellow Machine.46ccee.ttslua
+++ b/tts-mod/src/Yellow Machine.46ccee.ttslua
@@ -1089,6 +1089,10 @@ end
 function getProfileForModel(model, unit)
     local otherModelsProfile = nil
 
+    if model.profileID ~= nil then 
+        return unit.modelProfiles[model.profileID];
+    end
+
     for _,profile in pairs(unit.modelProfiles) do
         if profile.name == model.name then
             return profile


### PR DESCRIPTION
Seems to work ok with both my rosters (which use profileID) and original rosters from battlescribe (which use name equality)