### PR TITLE
Added changeable radius for synapse units

### DIFF
--- a/lua_modules/MatchedPlay.lua
+++ b/lua_modules/MatchedPlay.lua
@@ -190,14 +190,16 @@ local function handleOrbit(action)
         orbit.radius = orbit.radius - 1
         if orbit.radius < 1 then
             orbit.radius = 0
-            self.setVectorLines({})
-            return
         end
     elseif action > 0 then
         orbit.radius = orbit.radius + 1
     end
+
+    print(unitData.unitName .. " synapse radius changed to " .. orbit.radius)    
     
     self.setVectorLines({})
+
+    if orbit.radius == 0 then return end
     
     local baseRadius = determineBaseInInches(self)
     


### PR DESCRIPTION
Synapse units gain a purple ring around the unit of radius 6 from the base indicating the range of their synapse. The radius can be adjusted by pressing 1 to decrease the radius by 1 (a radius of 0 or less changes the radius to 0, then hides it) or pressing 2 to increase the radius by 1.

![image](https://github.com/user-attachments/assets/11294652-1bf3-47b7-b1ce-dc7b0d19ceaf)
